### PR TITLE
Add __init__.py file in tests/ to specify tests/ as a python module

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+# Using this file to make the tests directory into a python package.
+# Can then run tests using Pycharm and with the following bash command:
+# python -m unittest tests.test_all
+# OR
+# python -m unittest tests.test_all.<specific-test>


### PR DESCRIPTION
Add a simple __init__.py file to show that the tests directory should
be treated as a python module. This makes it easier to call the tests
from the command line and inside Pycharm.